### PR TITLE
Adding tab a bit buggy #214

### DIFF
--- a/lib/jquery.easytabs.js
+++ b/lib/jquery.easytabs.js
@@ -161,7 +161,7 @@
             // `href` attribute for non-ajax tabs, or in the
             // `data-target` attribute for ajax tabs since the `href` is
             // the ajax URL
-            targetId = $tab.children('a').data('target');
+            targetId = $a.data('target');
 
         $tab.data('easytabs', {});
 
@@ -185,7 +185,7 @@
           });
 
           // Don't hide panel if it's active (allows `getTabs` to be called manually to re-instantiate tab collection)
-          $matchingPanel.not(settings.panelActiveClass).hide();
+          $matchingPanel.not('.'+settings.panelActiveClass).hide();
 
           plugin.panels = plugin.panels.add($matchingPanel);
 
@@ -470,7 +470,7 @@
     // Bind tab-select funtionality to namespaced click event, called by
     // init
     var bindToTabClicks = function() {
-      plugin.tabs.children("a").bind(settings.bind_str, function(e) {
+      $container.on(settings.bind_str, settings.tabs + ' a' , function(e) {
 
         // Stop cycling when a tab is clicked
         settings.cycle = false;

--- a/lib/jquery.easytabs.js
+++ b/lib/jquery.easytabs.js
@@ -470,7 +470,7 @@
     // Bind tab-select funtionality to namespaced click event, called by
     // init
     var bindToTabClicks = function() {
-      $container.on(settings.bind_str, settings.tabs + ' a' , function(e) {
+      $container.on(settings.bind_str, settings.tabs + ' > a' , function(e) {
 
         // Stop cycling when a tab is clicked
         settings.cycle = false;


### PR DESCRIPTION
in getTabs() method is a line wich says it does not hide active panel if called afterwards, but it does actually due to typo.
than there is a bit performance issue in the same method

And lastly there is a bindToTabClicks method.
It does not work if I add an tab and call getTabs().
if plugin would use on method, it would work just fine even with added tabs.
It has little drawback ofcourse and it is compatibility with jquery < 1.7 ... but it seems pretty reasonable for me, as it is almost 4 years old release now ( http://blog.jquery.com/2011/11/03/jquery-1-7-released/ )
