### PR TITLE
Set height on container when not animating

### DIFF
--- a/lib/jquery.easytabs.js
+++ b/lib/jquery.easytabs.js
@@ -575,6 +575,11 @@
           }
         }
 
+        // Need to preserve height if not animating to prevent jumping to top of browser with short content
+        if ( !settings.animate ) {
+          $panelContainer.css({ 'min-height': $panelContainer.height() });
+        }
+
         // Change the active tab *first* to provide immediate feedback when the user clicks
         plugin.tabs.filter("." + settings.tabActiveClass).removeClass(settings.tabActiveClass).children().removeClass(settings.tabActiveClass);
         plugin.tabs.filter("." + settings.collapsedClass).removeClass(settings.collapsedClass).children().removeClass(settings.collapsedClass);


### PR DESCRIPTION
There is support during fade animation to set a height on the tabs container to prevent short pages from jumping back to the top when both tabs are hidden. This provides a similar feature to tabs that don't animate to avoid the same jump.
